### PR TITLE
Error handling and improve consistency 

### DIFF
--- a/controllers/category_controller.go
+++ b/controllers/category_controller.go
@@ -35,7 +35,7 @@ func GetCategory(c *fiber.Ctx) error {
 	err := c.ParamsParser(&param)
 
 	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"message": "Failed to get category", "error": "category not found"})
+		return c.Status(fiber.StatusUnprocessableEntity).JSON(fiber.Map{"message": "Failed to parse get category request", "error": err.Error()})
 	}
 
 	category, err := repo.GetCategory(param.ID)

--- a/controllers/category_controller.go
+++ b/controllers/category_controller.go
@@ -105,7 +105,7 @@ func UpdateCategory(c *fiber.Ctx) error {
 	category, err := repo.GetCategory(param.ID)
 
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"message": "Failed to update category", "error": "category not found"})
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"message": "Failed to update category", "error": "category not exist"})
 	}
 
 	if err != nil {

--- a/controllers/category_controller.go
+++ b/controllers/category_controller.go
@@ -98,10 +98,6 @@ func UpdateCategory(c *fiber.Ctx) error {
 
 	validate := validator.New()
 
-	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"message": "Failed to update category", "error": "category not found"})
-	}
-
 	category, err := repo.GetCategory(param.ID)
 
 	if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -148,19 +144,15 @@ func DeleteCategory(c *fiber.Ctx) error {
 	err := c.ParamsParser(&param)
 
 	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"message": "Failed to delete category", "error": "category not found"})
-	}
-
-	_, err = repo.GetCategory(param.ID)
-
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"message": "Failed to delete category", "error": "Category not exist"})
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"message": "Failed to delete category", "error": "category not exist"})
 	}
 
 	err = repo.DeleteCategory(param.ID)
 
-	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"message": "Failed to delete category", "error": err})
+	if err.Error() == "Data not exist" {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"message": "Failed to delete category", "error": err.Error()})
+	} else if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"message": "Failed to delete category", "error": err.Error()})
 	}
 
 	return c.JSON(fiber.Map{"message": "Category deleted successfully"})

--- a/controllers/category_controller.go
+++ b/controllers/category_controller.go
@@ -151,6 +151,12 @@ func DeleteCategory(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"message": "Failed to delete category", "error": "category not found"})
 	}
 
+	_, err = repo.GetCategory(param.ID)
+
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"message": "Failed to delete category", "error": "Category not exist"})
+	}
+
 	err = repo.DeleteCategory(param.ID)
 
 	if err != nil {

--- a/controllers/category_controller.go
+++ b/controllers/category_controller.go
@@ -31,9 +31,7 @@ func GetCategories(c *fiber.Ctx) error {
 }
 
 func GetCategory(c *fiber.Ctx) error {
-	param := struct {
-		ID uint `params:"id"`
-	}{}
+	param := dto.MenuParams{}
 	err := c.ParamsParser(&param)
 
 	if err != nil {
@@ -138,9 +136,7 @@ func UpdateCategory(c *fiber.Ctx) error {
 }
 
 func DeleteCategory(c *fiber.Ctx) error {
-	param := struct {
-		ID uint `params:"id"`
-	}{}
+	param := dto.CategoryParams{}
 	err := c.ParamsParser(&param)
 
 	if err != nil {

--- a/controllers/category_controller.go
+++ b/controllers/category_controller.go
@@ -36,12 +36,8 @@ func GetCategory(c *fiber.Ctx) error {
 	}{}
 	err := c.ParamsParser(&param)
 
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"message": "Failed to get category", "error": "category not found"})
-	}
-
 	if err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"message": "Failed to get category", "error": "invalid category id"})
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"message": "Failed to get category", "error": "category not found"})
 	}
 
 	category, err := repo.GetCategory(param.ID)

--- a/controllers/category_controller.go
+++ b/controllers/category_controller.go
@@ -31,7 +31,7 @@ func GetCategories(c *fiber.Ctx) error {
 }
 
 func GetCategory(c *fiber.Ctx) error {
-	param := dto.MenuParams{}
+	param := dto.CategoryParams{}
 	err := c.ParamsParser(&param)
 
 	if err != nil {

--- a/dto/category_dto.go
+++ b/dto/category_dto.go
@@ -12,3 +12,7 @@ type CategoryResponse struct {
 	ID   uint   `json:"id"`
 	Name string `json:"name"`
 }
+
+type CategoryParams struct {
+	ID uint `params:"id"`
+}

--- a/dto/user_dto.go
+++ b/dto/user_dto.go
@@ -2,5 +2,5 @@ package dto
 
 type UserRequest struct {
 	Username string `json:"username" validate:"required"`
-	Password string `json:"password" validate:"required"`
+	Password string `json:"password" validate:"required,min=8"`
 }

--- a/helpers/db.go
+++ b/helpers/db.go
@@ -1,0 +1,15 @@
+package helpers
+
+type NotExist struct{}
+
+func (e NotExist) Error() string {
+	return "Data not exist"
+}
+
+func CheckRowsAffected(rows int64) error {
+	if rows == 0 {
+		return NotExist{}
+	}
+
+	return nil
+}

--- a/middlewares/require_admin_middleware.go
+++ b/middlewares/require_admin_middleware.go
@@ -14,7 +14,7 @@ func RequireAdmin(c *fiber.Ctx) error {
 	}
 
 	if claims["role"] != models.RoleAdmin {
-		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"message": "Unauthorized", "error": "You are not authorized to access this resource"})
+		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"message": "Forbidden", "error": "You are not allowed to access this resource"})
 	}
 
 	err := c.Next()

--- a/middlewares/require_admin_middleware.go
+++ b/middlewares/require_admin_middleware.go
@@ -14,7 +14,7 @@ func RequireAdmin(c *fiber.Ctx) error {
 	}
 
 	if claims["role"] != models.RoleAdmin {
-		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"message": "Unauthorized", "error": "You are not authorized to access this resource"})
+		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"message": "Unauthorized", "error": "You are not authorized to access this resource"})
 	}
 
 	err := c.Next()

--- a/repositories/category_repository.go
+++ b/repositories/category_repository.go
@@ -12,9 +12,9 @@ func GetCategories() ([]models.Category, error) {
 	return categories, err
 }
 
-func GetCategory(id int) (models.Category, error) {
-	category := models.Category{ID: uint(id)}
-	err := db.DB.First(&category).Error
+func GetCategory(id uint) (models.Category, error) {
+	var category models.Category
+	err := db.DB.First(&category, id).Error
 
 	return category, err
 }
@@ -27,8 +27,8 @@ func UpdateCategory(category *models.Category) error {
 	return db.DB.Save(category).Error
 }
 
-func DeleteCategory(id int) error {
-	category := models.Category{ID: uint(id)}
+func DeleteCategory(id uint) error {
+	category := models.Category{ID: id}
 	err := db.DB.Delete(&category).Error
 
 	return err

--- a/repositories/category_repository.go
+++ b/repositories/category_repository.go
@@ -2,6 +2,7 @@ package repositories
 
 import (
 	db "warung-informatika-be/database"
+	"warung-informatika-be/helpers"
 	"warung-informatika-be/models"
 )
 
@@ -24,12 +25,21 @@ func CreateCategory(category *models.Category) error {
 }
 
 func UpdateCategory(category *models.Category) error {
-	return db.DB.Save(category).Error
+	res := db.DB.Save(category)
+	if err := helpers.CheckRowsAffected(res.RowsAffected); err != nil {
+		return err
+	}
+
+	return res.Error
 }
 
 func DeleteCategory(id uint) error {
 	category := models.Category{ID: id}
-	err := db.DB.Delete(&category).Error
+	res := db.DB.Delete(&category)
 
-	return err
+	if err := helpers.CheckRowsAffected(res.RowsAffected); err != nil {
+		return err
+	}
+
+	return res.Error
 }

--- a/repositories/menu_repository.go
+++ b/repositories/menu_repository.go
@@ -13,9 +13,9 @@ func GetMenus() ([]models.Menu, error) {
 	return menus, err
 }
 
-func GetMenu(id int) (models.Menu, error) {
-	var menu models.Menu
-	err := db.DB.Preload(clause.Associations).First(&menu, id).Error
+func GetMenu(id uint) (models.Menu, error) {
+	menu := models.Menu{ID: id}
+	err := db.DB.Preload(clause.Associations).First(&menu).Error
 
 	return menu, err
 }

--- a/seeders/seeder.go
+++ b/seeders/seeder.go
@@ -6,4 +6,5 @@ import (
 
 func Seed() {
 	UserSeeder(models.User{Username: "admin", Password: "akusayangpit123"})
+	UserSeeder(models.User{Username: "user", Role: models.RoleUser, Password: "akusayangpit123"})
 }

--- a/seeders/seeder.go
+++ b/seeders/seeder.go
@@ -5,6 +5,6 @@ import (
 )
 
 func Seed() {
-	UserSeeder(models.User{Username: "admin", Password: "akusayangpit123"})
+	UserSeeder(models.User{Username: "admin", Password: "akusayang(PIT):0"})
 	UserSeeder(models.User{Username: "user", Role: models.RoleUser, Password: "akusayangpit123"})
 }

--- a/seeders/user_seeder.go
+++ b/seeders/user_seeder.go
@@ -1,7 +1,9 @@
 package seeders
 
 import (
+	"errors"
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 	"log"
 	"warung-informatika-be/helpers"
 	"warung-informatika-be/models"
@@ -9,6 +11,12 @@ import (
 )
 
 func UserSeeder(user models.User) {
+	_, err := repo.GetUserByUsername(user.Username)
+
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		log.Fatal("Username already exist")
+	}
+
 	password, _ := helpers.HashPassword(user.Password)
 
 	user.ID, _ = uuid.NewV7()


### PR DESCRIPTION
This pull request includes several changes to improve error handling, enforce stricter validation, and update database operations in various parts of the codebase. The most important changes include modifying error messages, updating password validation, and adjusting repository methods to use `uint` for IDs.

Error handling improvements:

* [`controllers/category_controller.go`](diffhunk://#diff-a74b68b30ec7ea0be58f8cd6a158233b7796b608f0e882515776523c82421197L39-R40): Updated error messages in `GetCategory`, `UpdateCategory`, and `DeleteCategory` functions for better clarity. [[1]](diffhunk://#diff-a74b68b30ec7ea0be58f8cd6a158233b7796b608f0e882515776523c82421197L39-R40) [[2]](diffhunk://#diff-a74b68b30ec7ea0be58f8cd6a158233b7796b608f0e882515776523c82421197L112-R108) [[3]](diffhunk://#diff-a74b68b30ec7ea0be58f8cd6a158233b7796b608f0e882515776523c82421197R154-R159)
* [`middlewares/require_admin_middleware.go`](diffhunk://#diff-41cf1307a3c1710d4be326daa507d9e0bbdf696e685f81af196c006bf93dffeeL17-R17): Changed the error status and message to return `Forbidden` instead of `Unauthorized` when a user is not allowed to access a resource.

Validation enhancements:

* [`dto/user_dto.go`](diffhunk://#diff-584fdf096ada97f249218bc47c0f72679fde0671046a501b6ba929af567fee1bL5-R5): Added a minimum length requirement of 8 characters for the `Password` field in the `UserRequest` struct.

Repository method updates:

* [`repositories/category_repository.go`](diffhunk://#diff-c268101557b63ec0098289b8a6298ef92e9b3e06383b6640058d2819d09fbaf3L15-R17): Modified `GetCategory` and `DeleteCategory` functions to use `uint` for the `id` parameter. [[1]](diffhunk://#diff-c268101557b63ec0098289b8a6298ef92e9b3e06383b6640058d2819d09fbaf3L15-R17) [[2]](diffhunk://#diff-c268101557b63ec0098289b8a6298ef92e9b3e06383b6640058d2819d09fbaf3L30-R31)
* [`repositories/menu_repository.go`](diffhunk://#diff-dd3902cf3c763747fb407005123ef9de9e88fc0ddbf43a845bc4743e48e80ea9L16-R18): Updated `GetMenu` function to use `uint` for the `id` parameter.

Seeder adjustments:

* [`seeders/seeder.go`](diffhunk://#diff-3a74d6a733b77e42b5de59f12ed9eb1ce4a467e1d49a36229db59aaf840a6850L8-R9): Added a new user seeding entry and updated the admin password for seeding.
* [`seeders/user_seeder.go`](diffhunk://#diff-c56b40d81f23c31704539889f9353b14d7baddf2dcc775a0a018108a51716104R4-R19): Included a check to prevent duplicate usernames during user seeding.